### PR TITLE
Update Postgres Docker image version

### DIFF
--- a/docker-compose.migrate.yaml
+++ b/docker-compose.migrate.yaml
@@ -37,7 +37,7 @@ services:
       - ./scripts:/scripts
 
   ffc-sfd-messages-processor-postgres:
-    image: postgres:11.4-alpine
+    image: postgres:15
     environment: *common-postgres
     volumes:
       - postgres_data:/var/lib/postgresql/data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       CRM_TOPIC_ADDRESS: ${CRM_TOPIC_ADDRESS}-${DEV_SUFFIX}
 
   ffc-sfd-messages-processor-postgres:
-    image: postgres:11.4-alpine
+    image: postgres:15
     environment:
       POSTGRES_DB: ffc-sfd-messages-processor
       POSTGRES_PASSWORD: ppp

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-sfd-messages-processor",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "description": "",
   "homepage": "github.com?owner=defra&repo=ffc-sfd-messages-processor&organization=defra",
   "main": "app/index.js",


### PR DESCRIPTION
Changes in this PR are based on an email ADP sent to John on 20th May where they mention they would upgrade the current image version (postgres:11.4-alpine) to use postgres:15. John mentioned that we'd update our local development image to 15 as well to match, so this PR is for making those updates.
